### PR TITLE
Added links to interactive atlas

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -68,7 +68,8 @@ export default function App({ Component, pageProps }: AppProps) {
             game._users,
             false,
             game._availableRegions,
-            game._status
+            game._status,
+            game._ssp
           )
         );
       });

--- a/pages/visualize.tsx
+++ b/pages/visualize.tsx
@@ -3,9 +3,15 @@ import Head from "next/head";
 
 import Layout from "../components/layout";
 import Typography from "@mui/material/Typography";
+import Button from "@mui/material/Button";
 
 import { snackbarProps, socket } from "./_app";
-import { userState, gameState, GameStatus } from "../utils/types/game";
+import {
+  userState,
+  gameState,
+  GameStatus,
+  AtlasMeanTemperatureLinks,
+} from "../utils/types/game";
 
 export default function Visualize({
   user,
@@ -32,6 +38,22 @@ export default function Visualize({
           <Typography variant="h3" textAlign="center">
             Visualize Data: {game.ssp}
           </Typography>
+        )}
+        {game.status == GameStatus.visualize && (
+          <Typography variant="body1" textAlign="center">
+            SSP Description
+          </Typography>
+        )}
+        {game.status == GameStatus.visualize && (
+          <Button
+            variant="contained"
+            size="large"
+            href={AtlasMeanTemperatureLinks[game.ssp]}
+            target="_blank"
+            rel="noopener noreffer"
+          >
+            View Interactive Atlas
+          </Button>
         )}
       </Layout>
     </>

--- a/utils/socketServerHandler.tsx
+++ b/utils/socketServerHandler.tsx
@@ -107,7 +107,7 @@ export default (io: Server, socket: Socket, rooms: Map<string, Game>) => {
       if (game.allUsersCompletedQuestion()) {
         game.status = GameStatus.visualize;
         // TODO: process weights from users
-        game.ssp = SSP["1-1.9"];
+        game.ssp = SSP["1-2.6"];
         io.to(code).emit(socketEvent.game_update, game);
       }
     } else {

--- a/utils/types/game.tsx
+++ b/utils/types/game.tsx
@@ -37,7 +37,8 @@ export class Game {
     users: user[],
     newGame: boolean = false,
     availableRegions?: string[],
-    status?: GameStatus
+    status?: GameStatus,
+    ssp?: SSP
   ) {
     this._gameCode = gameCode;
     if (newGame) {
@@ -57,6 +58,10 @@ export class Game {
       this._status = status;
     } else {
       this._status = GameStatus.lobby;
+    }
+
+    if (ssp) {
+      this._ssp = ssp;
     }
   }
 
@@ -167,12 +172,19 @@ export interface answer {
 }
 
 export enum SSP {
-  "1-1.9",
-  "1-2.6",
-  "2-4.5",
-  "3-7.0",
-  "4-3.4",
-  "4-6.0",
-  "5-3.4OS",
-  "5-8.5",
+  "1-1.9" = "SSP 1-1.9",
+  "1-2.6" = "SSP 1-2.6",
+  "2-4.5" = "SSP 2-4.5",
+  "3-7.0" = "SSP 3-7.0",
+  "4-3.4" = "SSP 4-3.4",
+  "4-6.0" = "SSP 4-6.0",
+  "5-3.4OS" = "SSP 5-3.4OS",
+  "5-8.5" = "SSP 5-8.5",
 }
+
+export const AtlasMeanTemperatureLinks = {
+  [SSP["1-2.6"]]: "https://interactive-atlas.ipcc.ch/permalink/kb5pXfjf",
+  [SSP["2-4.5"]]: "https://interactive-atlas.ipcc.ch/permalink/DknmXOcr",
+  [SSP["3-7.0"]]: "https://interactive-atlas.ipcc.ch/permalink/l9ZvwmMd",
+  [SSP["5-8.5"]]: "https://interactive-atlas.ipcc.ch/permalink/TKJP21BH",
+};


### PR DESCRIPTION
Closes #25 
Once all the users are completed with their questions, the resulting SSP has a link to the interactive atlas.

Limitations:

- There are only 4 SSP options instead of the 8 actual options.
- Cannot load the data in an iFrame as the atlas prohibits the behavior. Should look into pop up window? (#28)